### PR TITLE
[feat] 리뷰 조회시 작성자 이름 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.8.4",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
+        "jwt-decode": "^4.0.0",
         "lodash.debounce": "^4.0.8",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3251,6 +3252,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.8.4",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
+    "jwt-decode": "^4.0.0",
     "lodash.debounce": "^4.0.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/pages/ReviewPage/ReviewRead.tsx
+++ b/src/pages/ReviewPage/ReviewRead.tsx
@@ -140,6 +140,7 @@ interface Site {
 interface Review {
   id: number;
   sightId: number;
+  userName: string;
   content: string;
   date: string; // "2025-05-10" 같은 ISO 문자열
   advantages: string[]; // 태그 리스트
@@ -291,7 +292,7 @@ const ReviewPage: React.FC = () => {
             reviews.map((review) => (
               <ReviewItem
                 key={review.id}
-                userName="김지훈"
+                userName={review.userName}
                 date={formatReviewDate(review.date)}
                 content={review.content}
                 // 여기서 tag마다 아이콘을 붙여줌


### PR DESCRIPTION
## 📄 작업 내용 요약
1. 리뷰 조회시 로그인한 사용자의 이름을 렌더링(기존엔 하드코딩 값이었음)


## 📎 Issue 번호
<!-- closed #번호 -->
